### PR TITLE
MAINT: small fixes to Huber doc and examples

### DIFF
--- a/examples/solvers/pdhg_denoising_L1_HuberTV.py
+++ b/examples/solvers/pdhg_denoising_L1_HuberTV.py
@@ -1,6 +1,6 @@
 """Total variation denoising using PDHG.
 
-This exhaustive example solves the L1-HuberTV problem
+This example solves the L1-HuberTV problem
 
         min_{x >= 0} ||x - d||_1
             + lam * sum_i eta_gamma(||grad(x)_i||_2)
@@ -16,8 +16,6 @@ https://odlgroup.github.io/odl/guide/pdhg_guide.html in the ODL documentation.
 import numpy as np
 import odl
 import matplotlib.pyplot as plt
-
-# --- define setting --- #
 
 # Define ground truth, space and noisy data
 shape = [100, 100]

--- a/examples/solvers/pdhg_denoising_L2_HuberTV.py
+++ b/examples/solvers/pdhg_denoising_L2_HuberTV.py
@@ -30,8 +30,6 @@ import scipy
 import odl
 import matplotlib.pyplot as plt
 
-# --- define setting --- #
-
 # Define ground truth, space and noisy data
 image = np.rot90(scipy.misc.ascent()[::2, ::2].astype('float'), 3)
 shape = image.shape
@@ -75,14 +73,14 @@ niter = 200  # number of iterations
 
 
 # Parameters for algorithm 1
-# Related to root of problem condition number
+# Related to the root of the problem condition number
 kappa1 = np.sqrt(1 + 0.999 * norm_op ** 2 / (mu_g * mu_f))
 tau1 = 1 / (mu_g * (kappa1 - 1))  # Primal step size
 sigma1 = 1 / (mu_f * (kappa1 - 1))  # Dual step size
 theta1 = 1 - 2 / (1 + kappa1)  # Extrapolation constant
 
 # Parameters for algorithm 2
-# Square root of problem condition number
+# Square root of the problem condition number
 kappa2 = norm_op / np.sqrt(mu_f * mu_g)
 tau2 = 1 / norm_op * np.sqrt(mu_f / mu_g)  # Primal step size
 sigma2 = 1 / norm_op * np.sqrt(mu_g / mu_f)  # Dual step size
@@ -104,7 +102,7 @@ odl.solvers.pdhg(x2, f, g, op, tau2, sigma2, niter, theta=theta2,
 obj2 = callback.callbacks[1].obj_function_values
 
 # %% Display results
-# show images
+# Show images
 clim = [0, 1]
 cmap = 'gray'
 
@@ -113,7 +111,7 @@ d.show('noisy', clim=clim, cmap=cmap)
 x1.show('denoised, alg1', clim=clim, cmap=cmap)
 x2.show('denoised, alg2', clim=clim, cmap=cmap)
 
-# show convergence rate
+# Show convergence rate
 min_obj = min(obj1 + obj2)
 
 
@@ -122,18 +120,18 @@ def rel_fun(x):
     return (x - min_obj) / (x[0] - min_obj)
 
 
-i = np.array(callback.callbacks[1].iteration_counts)
+iters = np.array(callback.callbacks[1].iteration_counts)
 
 plt.figure()
-plt.semilogy(i, rel_fun(obj1), color='red',
+plt.semilogy(iters, rel_fun(obj1), color='red',
              label='alg1, Chambolle et al 2017')
-plt.semilogy(i, rel_fun(obj2), color='blue',
+plt.semilogy(iters, rel_fun(obj2), color='blue',
              label='alg2, Chambolle and Pock 2011')
 rho = theta1
-plt.semilogy(i[1:], rho ** i[1:], '--', color='red',
+plt.semilogy(iters[1:], rho ** iters[1:], '--', color='red',
              label='$O(\\rho_1^k), \\rho_1={:3.2f}$'.format(rho))
 rho = theta2
-plt.semilogy(i[1:], rho ** i[1:], '--', color='blue',
+plt.semilogy(iters[1:], rho ** iters[1:], '--', color='blue',
              label='$O(\\rho_2^k), \\rho_2={:3.2f}$'.format(rho))
 plt.title('Function values + theoretical upper bounds')
 plt.ylim((1e-16, 1))

--- a/odl/solvers/functional/default_functionals.py
+++ b/odl/solvers/functional/default_functionals.py
@@ -2305,8 +2305,8 @@ class Huber(Functional):
     .. math::
         F(x) = \\int_\Omega f_{\\gamma}(||x(y)||_2) dy
 
-    where ``||.||_2`` denotes the Euclidean norm for vector-valued functions
-    which reduces to the absolute value for scalar-valued functions.
+    where :mth:`||\cdot||_2` denotes the Euclidean norm for vector-valued
+    functions which reduces to the absolute value for scalar-valued functions.
     The function :math:`f` with smoothing :math:`\\gamma` is given by
 
     .. math::
@@ -2325,9 +2325,9 @@ class Huber(Functional):
         space : `FnBase`
             Domain of the functional.
         gamma : float
-            Smoothing parameter of the Huber functional. If ``gamma = 0``, then
-            functional is non-smooth and corresponds to the usual L1 norm. For
-            ``gamma > 0``, it has a ``1/gamma``-Lipschitz gradient so that
+            Smoothing parameter of the Huber functional. If ``gamma = 0``,
+            the functional is non-smooth and corresponds to the usual L1 norm.
+            For ``gamma > 0``, it has a ``1/gamma``-Lipschitz gradient so that
             its convex conjugate is ``gamma``-strongly convex.
 
         Examples
@@ -2410,7 +2410,7 @@ class Huber(Functional):
 
     @property
     def convex_conj(self):
-        '''The convex conjugate'''
+        """The convex conjugate"""
         if isinstance(self.domain, ProductSpace):
             norm = GroupL1Norm(self.domain, 2)
         else:


### PR DESCRIPTION
Some small changes. When I looked at the L1 example in my editor it turned out it wasn't at all large after all. Maybe looking at it in the browser distorts perception..